### PR TITLE
ft-cancel-delivery-order-161698602

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,6 +1,6 @@
 from flask_restful import Api, Resource
 from flask import Blueprint
-from app.api.v1.views.orders_view import DeliveryOrders, DeliveryOrder
+from app.api.v1.views.orders_view import DeliveryOrders, DeliveryOrder, DeliveryOrderUpdate
 from app.api.v1.views.users_view import UserOrders
 
 version1 = Blueprint('sendit', __name__, url_prefix="/api/v1")
@@ -9,4 +9,5 @@ api = Api(version1)
 
 api.add_resource(DeliveryOrders, '/parcels')
 api.add_resource(DeliveryOrder, '/parcels/<parcelId>')
+api.add_resource(DeliveryOrderUpdate, '/parcels/<parcelId>/cancel')
 api.add_resource(UserOrders, '/users/<int:userId>/parcels')

--- a/app/api/v1/models/orders_model.py
+++ b/app/api/v1/models/orders_model.py
@@ -13,6 +13,7 @@ orders = [{
     "sender": 1
 }]
 
+
 class OrdersModel(object):
 
     def __init__(self):
@@ -55,6 +56,17 @@ class OrdersModel(object):
 
         for order in orders:
             if order['order no'] == order_id:
+                result = order
+                break
+
+        return result
+
+    def cancel_order(self, order_id):
+        result = {"message": "order unknown"}
+
+        for order in orders:
+            if order['order no'] == order_id:
+                order['status'] = "canceled"
                 result = order
                 break
 

--- a/app/api/v1/views/orders_view.py
+++ b/app/api/v1/views/orders_view.py
@@ -33,5 +33,20 @@ class DeliveryOrder(Resource, OrdersModel):
         result = self.db.get_order(parcelId)
 
         return make_response(jsonify(result))
+
+    def put(self, parcelId):
+        result = self.db.cancel_order(parcelId)
+
+        return make_response(jsonify(result))
+
+class DeliveryOrderUpdate(Resource, OrdersModel):
+
+    def __init__(self):
+        self.db = OrdersModel()
+
+    def put(self, parcelId):
+        result = self.db.cancel_order(parcelId)
+
+        return make_response(jsonify({"message": "order " + parcelId + " is canceled!", "Order " + parcelId: result}))
         
 


### PR DESCRIPTION
#### What does this PR do?
enable to cancel a delivery order created
#### Description of Task to be completed?
pr should have:
1 model function to cancel delivery order
2 PUT /parcels/<parcelId>/cancel endpoint
#### How should this be manually tested?
1. on postman enter the url http://127.0.0.1:5000/api/v1/parcels/678356/cancel
2. should return delivery order of order number 678356
3 status should be canceled
4 response code is 200
#### What are the relevant pivotal tracker stories?
#161698602
#### Screenshots (if appropriate)
![screenshot from 2018-11-07 16-33-18](https://user-images.githubusercontent.com/39084014/48135047-daecbb80-e2ac-11e8-8718-470083f4a7d7.png)
