### PR TITLE
ft-change-delivery-location-161698854

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,6 +1,6 @@
 from flask_restful import Api, Resource
 from flask import Blueprint
-from app.api.v1.views.orders_view import DeliveryOrders, DeliveryOrder, DeliveryOrderUpdate
+from app.api.v1.views.orders_view import DeliveryOrders, DeliveryOrder, DeliveryOrderUpdate, DeliveryOrderDeliveryUpdate
 from app.api.v1.views.users_view import UserOrders
 
 version1 = Blueprint('sendit', __name__, url_prefix="/api/v1")
@@ -10,4 +10,5 @@ api = Api(version1)
 api.add_resource(DeliveryOrders, '/parcels')
 api.add_resource(DeliveryOrder, '/parcels/<parcelId>')
 api.add_resource(DeliveryOrderUpdate, '/parcels/<parcelId>/cancel')
+api.add_resource(DeliveryOrderDeliveryUpdate, '/parcels/<parcelId>/change-delivery')
 api.add_resource(UserOrders, '/users/<int:userId>/parcels')

--- a/app/api/v1/models/orders_model.py
+++ b/app/api/v1/models/orders_model.py
@@ -84,6 +84,17 @@ class OrdersModel(object):
 
         return result
 
+    def change_delivery(self, order_id, delivery_location):
+        result = {"message": "order unknown"}
+
+        for order in orders:
+            if order['order no'] == order_id:
+                order['current location'] = delivery_location
+                result = order
+                break
+
+        return result
+
     def get_user_orders(self, user_id):
         user_orders = []
         for order in orders:

--- a/app/api/v1/views/orders_view.py
+++ b/app/api/v1/views/orders_view.py
@@ -52,3 +52,14 @@ class DeliveryOrderUpdate(Resource, OrdersModel):
         result = self.db.cancel_order(parcelId)
 
         return make_response(jsonify({"message": "order " + parcelId + " is canceled!", "Order " + parcelId: result}))
+
+class DeliveryOrderDeliveryUpdate(Resource, OrdersModel):
+
+    def __init__(self):
+        self.db = OrdersModel()
+
+    def put(self, parcelId):
+        data = request.get_json(force=True)
+        result = self.db.change_delivery(parcelId, data['delivery location'])
+
+        return make_response(jsonify({"message": "order " + parcelId + "Delivery location changed!", "Order " + parcelId: result}))


### PR DESCRIPTION
#### What does this PR do?
enables to change delivery location

#### Description of Task to be completed?
should have:
1 model method to change delivery location
2 endpoint PUT /parcels/<parcelId>/change-delivery

#### How should this be manually tested?
1 on postman, enter url http://127.0.0.1:5000/api/v1/parcels/678356/change-delivery
2 send a put request with required delivery location
3 should return delivery order "678356" with new delivery location
4 response code is 200
5 run pytest, the test should pass

#### What are the relevant pivotal tracker stories?
#161698854
#### Screenshots (if appropriate)
![screenshot from 2018-11-08 12-28-32](https://user-images.githubusercontent.com/39084014/48190409-ad0e8200-e353-11e8-8943-b42b7fae0eea.png)
![screenshot from 2018-11-08 12-29-14](https://user-images.githubusercontent.com/39084014/48190541-0aa2ce80-e354-11e8-9971-f2b562b0971b.png)
