### PR TITLE
#161698887 get the number of delivered orders for specific user

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,7 +1,7 @@
 from flask_restful import Api, Resource
 from flask import Blueprint
 from app.api.v1.views.orders_view import DeliveryOrders, DeliveryOrder, DeliveryOrderUpdate, DeliveryOrderDeliveryUpdate
-from app.api.v1.views.users_view import UserOrders
+from app.api.v1.views.users_view import UserOrders, UserDeliveredOrders
 
 version1 = Blueprint('sendit', __name__, url_prefix="/api/v1")
 
@@ -12,3 +12,4 @@ api.add_resource(DeliveryOrder, '/parcels/<parcelId>')
 api.add_resource(DeliveryOrderUpdate, '/parcels/<parcelId>/cancel')
 api.add_resource(DeliveryOrderDeliveryUpdate, '/parcels/<parcelId>/change-delivery')
 api.add_resource(UserOrders, '/users/<int:userId>/parcels')
+api.add_resource(UserDeliveredOrders, '/users/<int:userId>/delivered')

--- a/app/api/v1/models/orders_model.py
+++ b/app/api/v1/models/orders_model.py
@@ -106,3 +106,15 @@ class OrdersModel(object):
                 user_orders.append(order)
 
         return user_orders
+
+    def get_delivered_orders(self, user_id):
+        user_orders = []
+        for order in orders:
+            if order['sender'] == user_id and order['status'] == 'delivered':
+                for user in self.users:
+                    if user['user id'] == order['sender']:
+                        order['sender'] = user['username']
+                        break
+                user_orders.append(order)
+
+        return len(user_orders)

--- a/app/api/v1/views/users_view.py
+++ b/app/api/v1/views/users_view.py
@@ -15,3 +15,16 @@ class UserOrders(Resource, UsersModel, OrdersModel):
         result = self.orders.get_user_orders(userId)
 
         return make_response(jsonify({"Title": "Delivery orders by " + user['username'], "Delivery orders list": result}))
+
+
+class UserDeliveredOrders(Resource, UsersModel, OrdersModel):
+
+    def __init__(self):
+        self.db = UsersModel()
+        self.orders = OrdersModel()
+
+    def get(self, userId):
+        user = self.db.get_user(userId)
+        result = self.orders.get_delivered_orders(userId)
+
+        return make_response(jsonify({"Delivered orders for " + user['username'] : result}))

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -108,11 +108,11 @@ class TestDeliveryOrders(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
 
         response = self.app.get(
-            '/api/v1/users/1/parcels', content_type='application/json')
+            '/api/v1/users/1/delivered', content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
         result = json.loads(response.data)
-        self.assertIn('delivered', str(result))
+        self.assertIn('Delivered', str(result))
 
     def test_get_in_transit_orders_for_user(self):
         response = self.app.post(


### PR DESCRIPTION
#### What does this PR do?
gets the number of delivered orders created by a specific user

#### Description of Task to be completed?
should have:
1 model method to get the number of delivery orders
2 GET /users/<userId>/delivered endpoint

#### How should this be manually tested?
1 on postman, enter url http://127.0.0.1:5000/api/v1/users/1/delivered
2 send get method
3 should return the number of delivered orders created by user 1
4 response code is 200
5 run pytest, the test should pass

#### What are the relevant pivotal tracker stories?
#161698887
#### Screenshots (if appropriate)
![screenshot from 2018-11-08 13-11-32](https://user-images.githubusercontent.com/39084014/48193052-9ddf0280-e35a-11e8-86df-275b5ea04735.png)
![screenshot from 2018-11-08 13-12-30](https://user-images.githubusercontent.com/39084014/48193069-a6373d80-e35a-11e8-9ec1-127f02362e39.png)

